### PR TITLE
Option 3 improvement, unset pkg each loop

### DIFF
--- a/pacli
+++ b/pacli
@@ -189,7 +189,7 @@ fix_errors()
             sudo pacman -U "manjaro-keyring${version}-any.pkg.tar.xz" --noconfirm && \
             sudo rm "manjaro-keyring${version}-any.pkg.tar.xz"
 
-        # the following command sometimes prevents an error connecting to the key server		
+        # the following command sometimes prevents an error connecting to the key server
         sudo dirmngr </dev/null
         echo "pacman-key --init"
         sudo pacman-key --init && \
@@ -362,6 +362,7 @@ main()
 {
   declare arg="$1"
   while true; do
+    unset pkg
     menu_show "$screen_buffer"
     choix="$(read_choice "$arg")"
     arg=''
@@ -383,28 +384,30 @@ main()
             helper -Qdt
             paccache -ruvk0
             paccache -rvk2
-			
-			disk=$(lsblk -o "name,mountpoint" -pa | sed -n '/^\//h;/\/$/{g;p}' | cut -d/ -f3)
-			disk="${disk:0:3}"
-			if [[ -n "$disk" && -e "/dev/$disk" ]]; then
+
+            disk=$(lsblk -o "name,mountpoint" -pa | sed -n '/^\//h;/\/$/{g;p}' | cut -d/ -f3)
+            disk="${disk:0:3}"
+            if [[ -n "$disk" && -e "/dev/$disk" ]]; then
                 [[ $(cat $(find /sys -name 'rotational' 2>/dev/null | grep "$disk/queue")) == "1" ]] \
                     && sudo pacman-optimize
-			fi
-			unset disk
-			
-			echo
+            fi
+            unset disk
+            echo
             print_hook
             print_prompt "$(gettext 'System is updated and cache is cleaned')." "" 1
-			;;
+            ;;
         3)
             echo
             pkg=($(print_enter "$(gettext 'Select packages to install (use TAB to toggle selection)')" \
                 "$(helper_listdesc)" '-m' ))
-            sudo pacman -S "${pkg[@]}" --color always
-            unset pkg
-            echo
-            print_hook
-            print_prompt "$(gettext 'Package installation is finished')." "" 1
+            if [[ ${#pkg[@]} > 0 ]]; then
+                sudo pacman -S "${pkg[@]}" --color always
+                echo
+                print_hook
+                print_prompt "$(gettext 'Package installation is finished')." "" 1
+            else
+                continue
+            fi
             ;;
         4)
             echo
@@ -448,12 +451,11 @@ main()
             (($?!=0)) && continue
             [ -z "$pkg" ] && continue
             downgrade "${pkg}"
-            unset pkg
             print_prompt "$(gettext 'Downgrade process finished')." "" 1
             ;;
         12)
             echo
-			$(print_enter "$(gettext 'Enter one or more filter terms')" "$(tail -2000 /var/log/pacman.log)" '-m +s -q alpm --tac' ) >> /tmp/pacli-log			
+            $(print_enter "$(gettext 'Enter one or more filter terms')" "$(tail -2000 /var/log/pacman.log)" '-m +s -q alpm --tac' ) >> /tmp/pacli-log			
             ;;
         13)
             help_text $choix "${PARAMS['helpred']}" || continue
@@ -473,7 +475,6 @@ main()
             (($?!=0)) && continue
             [ -z "$pkg" ] && continue
             sudo pacman -S --force "$pkg" --color always
-            unset pkg
             print_prompt "$(gettext 'Package installation in force mode is finished')." "" 1
             ;;
         16)
@@ -489,7 +490,6 @@ main()
             (($?!=0)) && continue
             [ -z "$pkg" ] && continue
             sudo pacman -Rdd "$pkg" --color always
-            unset pkg
             print_prompt "$(gettext 'Dependency in force mode removed')." "" 1
             ;;
         18)
@@ -528,7 +528,6 @@ main()
             (($?!=0)) && continue
             [ -z "$pkg" ] && continue
             helper -S "${pkg[*]}"
-            unset pkg
             print_prompt "$(gettext 'Installation from AUR finished')." "" 1
             ;;
         220)


### PR DESCRIPTION
During option 3 'Install Package' pressing enter immediately will result in an attempted install of nothing
which prompts user to enter password, this is just a small check if a package wasn't chosen just return to the main menu.
This is done instantly without prompting the user, it felt clunky to be at the menu already and have to press enter to use it.

I opted to unset pkg while looping rather than within the case itself, I figured because it was being unset in a few places might as well save a few lines and just do it each loop. Last thing was a bit of whitespace/tab cleanup