### PR TITLE
pacli: removed dangerous `-Sy` commands.

### DIFF
--- a/pacli
+++ b/pacli
@@ -165,7 +165,7 @@ package_list_files() {
 fix_errors() {
     declare cmd url version arch keys
     sudo rm -f /var/lib/pacman/db.lck
-    cmd=(sudo pacman -Syy)
+    cmd=(sudo pacman -Syyu)
     keys=(
     'AEFB411B072836CD48FF0381AE252C284B5DBA5D'
     '9E4F11C6A072942A7B3FD3B0B81EB14A09A25EB0'
@@ -211,7 +211,7 @@ fix_errors() {
     elif hash reflector >/dev/null 2>&1; then
         sudo reflector --verbose --score 100 --fastest 25 \
             --sort rate --save /etc/pacman.d/mirrorlist && "${cmd[@]}"
-        sudo pacman -Sy gnupg archlinux-keyring && sudo rm -r /etc/pacman.d/gnupg && \
+        sudo pacman -Syu gnupg archlinux-keyring && sudo rm -r /etc/pacman.d/gnupg && \
             sudo pacman-key --init && sudo pacman-key --populate archlinux \
             && sudo pacman-key --refresh-keys
     else
@@ -374,7 +374,7 @@ main() {
             2)
                 echo
                 sudo reflector --verbose --score 100 --fastest 25 --sort rate \
-                    --save /etc/pacman.d/mirrorlist && sudo pacman -Syy --color always
+                    --save /etc/pacman.d/mirrorlist && sudo pacman -Syyu --color always
                 helper -Qdt
                 paccache -ruvk0
                 paccache -rvk2


### PR DESCRIPTION
Using `pacman -Sy` and then installing packages without also upgrading the rest of the system is known as a "partial upgrade" and is completely unsupported by the Arch developers because soname bumps (which are common in Arch) can break the system.

I've made all the calls in this script "safe" by adding the -u flag.

I would have just raised an issue about this rather than bluntly submitting a PR but Issues appear to be disabled for your repositories.